### PR TITLE
fix: use semver-compliant version format for dev builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,8 +152,8 @@ jobs:
           # Get short commit hash
           COMMIT_HASH=$(git rev-parse --short HEAD)
 
-          # Create dev version: dev.abc1234
-          DEV_VERSION="dev.${COMMIT_HASH}"
+          # Create dev version: 0.0.0-dev.abc1234 (valid semver prerelease)
+          DEV_VERSION="0.0.0-dev.${COMMIT_HASH}"
 
           echo "dev_version=$DEV_VERSION" >> $GITHUB_OUTPUT
           echo "✅ Development version: $DEV_VERSION"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,14 +110,14 @@ We follow [Semantic Versioning](https://semver.org/):
 
 Every push to the `main` branch automatically publishes development builds to GHCR:
 
-- **Version format**: `dev.<commit-hash>` (e.g., `dev.abc1234`)
+- **Version format**: `0.0.0-dev.<commit-hash>` (e.g., `0.0.0-dev.abc1234`)
 - **Purpose**: Testing unreleased features before creating a stable release
 - **Not for production**: Development builds are ephemeral and may contain breaking changes
 
 Example:
 ```bash
 # Install a development build for testing
-helm install synaplan oci://ghcr.io/metadist/synaplan-charts/synaplan --version dev.abc1234
+helm install synaplan oci://ghcr.io/metadist/synaplan-charts/synaplan --version 0.0.0-dev.abc1234
 ```
 
 ## Chart Guidelines

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ helm install synaplan oci://ghcr.io/metadist/synaplan-charts/synaplan --version 
 helm install triton oci://ghcr.io/metadist/synaplan-charts/triton --version 0.1.0
 
 # Or install a development build (for testing unreleased features)
-# Development builds are tagged as: dev.<commit-hash>
-helm install synaplan oci://ghcr.io/metadist/synaplan-charts/synaplan --version dev.abc1234
+# Development builds are tagged as: 0.0.0-dev.<commit-hash>
+helm install synaplan oci://ghcr.io/metadist/synaplan-charts/synaplan --version 0.0.0-dev.abc1234
 ```
 
 > **Note**: Charts are publicly accessible. Authentication is only required for publishing.
 >
 > **Versioning**:
 > - **Stable releases** (`0.1.0`, `0.2.0`, etc.) - Created from git tags, immutable, production-ready
-> - **Development builds** (`dev.abc1234`) - Built from main branch on every push, for testing only
+> - **Development builds** (`0.0.0-dev.abc1234`) - Built from main branch on every push, for testing only
 
 ### Install from Source
 


### PR DESCRIPTION
Change dev version format from dev.abc1234 to 0.0.0-dev.abc1234 to satisfy Helm's semver validation requirements