### PR TITLE
fix: ensure database schema is ready before model initialization

### DIFF
--- a/charts/synaplan/templates/init-scripts-configmap.yaml
+++ b/charts/synaplan/templates/init-scripts-configmap.yaml
@@ -59,6 +59,12 @@ data:
 
     cd /var/www/backend
 
+    # Ensure database schema is ready
+    # FIXME: this is a hack until we properly handle migrations and DATABASE_*_URLs
+    echo "🔄 Running database schema update..."
+    php bin/console doctrine:schema:update --force
+    echo "✅ Database schema ready!"
+
     # Note: SQL queries below use hardcoded strings only (no variable interpolation)
     # This is safe from SQL injection as all values are defined in the Helm template
     #


### PR DESCRIPTION
Add doctrine:schema:update --force before inserting Triton models. This fixes the issue where the BMODELS table doesn't exist yet on first startup.