### PR TITLE
Using ollama instead of triton

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ This repository contains the following charts:
 
 ## AI Backends
 
-Synaplan supports:
-- **NVIDIA Triton** (Recommended for production GPU clusters)
-- **Ollama** (Recommended for local/dev or smaller GPU setups)
+Synaplan uses [BGE-M3](https://huggingface.co/BAAI/bge-m3) as its embedding model for RAG-powered semantic search across 100+ languages. The embedding model (and chat LLMs) run on whichever backend you configure:
+
+- **[Ollama](https://ollama.com/)** — Recommended for most deployments. Simple setup, supports CPU and GPU inference, broad model support.
+- **[NVIDIA Triton](https://developer.nvidia.com/triton-inference-server)** — For production GPU clusters requiring maximum throughput with TensorRT-LLM optimized models.
 
 ## Installation
 

--- a/charts/synaplan/README.md
+++ b/charts/synaplan/README.md
@@ -35,13 +35,44 @@ helm install synaplan ./charts/synaplan
 
 ## Configuration
 
-## AI Backend Configuration
+### AI Backend Configuration
 
-Synaplan supports multiple AI backends for LLM inference. You can use either **NVIDIA Triton** (for high-performance production setups) or **Ollama** (for simpler local deployments).
+Synaplan supports multiple AI backends for LLM inference and embedding. You can use either **NVIDIA Triton** or **Ollama** depending on your infrastructure needs.
 
-### Option 1: NVIDIA Triton (Default)
+#### Embedding Model: bge-m3
 
-Triton is the default backend. It requires a separate Triton deployment (see `../triton` chart).
+Synaplan uses [BGE-M3](https://huggingface.co/BAAI/bge-m3) as its embedding model for RAG (Retrieval-Augmented Generation). BGE-M3 is a multilingual, multi-granularity embedding model that supports over 100 languages and produces high-quality vector representations for semantic search. The embedding model runs on whichever backend you configure (Triton or Ollama).
+
+#### Option 1: Ollama (Recommended)
+
+[Ollama](https://ollama.com/) is a lightweight, easy-to-deploy inference server that supports both LLM chat and embedding models. It is the recommended backend for most deployments — whether local development, single-node GPU servers, or smaller production clusters.
+
+Ollama advantages:
+- Simple setup — single binary or container, no model compilation step
+- Supports CPU and GPU inference out of the box
+- Easy model management (`ollama pull`, `ollama run`)
+- Broad model support (Mistral, Llama, Gemma, BGE-M3, etc.)
+
+```yaml
+triton:
+  url: ""  # Disable Triton
+ollama:
+  baseUrl: "http://ollama.synaplan.svc.cluster.local:11434"
+```
+
+To deploy Ollama in your cluster, you can use the [ollama-helm](https://github.com/otwld/ollama-helm) chart or run it as a standalone container.
+
+#### Option 2: NVIDIA Triton
+
+[NVIDIA Triton Inference Server](https://developer.nvidia.com/triton-inference-server) is a high-performance inference platform designed for production GPU clusters. Use Triton when you need maximum throughput with TensorRT-LLM optimized models.
+
+Triton advantages:
+- TensorRT-LLM compiled models for maximum GPU throughput
+- Dynamic batching and model concurrency
+- Multi-model serving with fine-grained resource control
+- Production-grade metrics and monitoring
+
+Triton requires a separate deployment using the `triton` chart included in this repository:
 
 ```yaml
 triton:
@@ -50,19 +81,7 @@ ollama:
   baseUrl: ""
 ```
 
-### Option 2: Ollama
-
-To use Ollama instead of Triton:
-
-1.  Deploy Ollama in your cluster (e.g., using `ollama-helm`).
-2.  Configure Synaplan to point to Ollama and disable Triton.
-
-```yaml
-triton:
-  url: ""  # Disable Triton
-ollama:
-  baseUrl: "http://ollama.synaplan.svc.cluster.local:11434"
-```
+See the [triton chart](../triton/) for deployment instructions and TensorRT-LLM build configuration.
 
 ## Values
 
@@ -111,7 +130,7 @@ ollama:
 | oidc.clientSecretRef | string | `""` |  |
 | oidc.enabled | bool | `false` |  |
 | oidc.issuerURI | string | `""` |  |
-| ollama.baseUrl | string | `""` |  |
+| ollama.baseUrl | string | `""` | Ollama API base URL. Set this to use Ollama for LLM inference and bge-m3 embedding. Example: http://ollama.synaplan.svc.cluster.local:11434 |
 | persistence.uploads.accessMode | string | `"ReadWriteMany"` |  |
 | persistence.uploads.enabled | bool | `false` |  |
 | persistence.uploads.existingClaim | string | `""` |  |
@@ -135,8 +154,8 @@ ollama:
 | tika.enabled | bool | `false` |  |
 | tika.url | string | `"http://tika.synaplan.svc.cluster.local:9998"` |  |
 | tolerations | list | `[]` |  |
-| triton.url | string | `"triton:8001"` |  |
-| tritonMode | string | `"gpu"` |  |
+| triton.url | string | `"triton:8001"` | Triton gRPC endpoint URL. Leave empty to disable Triton backend. |
+| tritonMode | string | `"gpu"` | Triton deployment mode (cpu or gpu) - determines which model to register in database |
 | volumeMounts | list | `[]` |  |
 | volumes | list | `[]` |  |
 

--- a/charts/synaplan/README.md.gotmpl
+++ b/charts/synaplan/README.md.gotmpl
@@ -34,6 +34,54 @@ helm install synaplan ./charts/synaplan
 
 ## Configuration
 
+### AI Backend Configuration
+
+Synaplan supports multiple AI backends for LLM inference and embedding. You can use either **NVIDIA Triton** or **Ollama** depending on your infrastructure needs.
+
+#### Embedding Model: bge-m3
+
+Synaplan uses [BGE-M3](https://huggingface.co/BAAI/bge-m3) as its embedding model for RAG (Retrieval-Augmented Generation). BGE-M3 is a multilingual, multi-granularity embedding model that supports over 100 languages and produces high-quality vector representations for semantic search. The embedding model runs on whichever backend you configure (Triton or Ollama).
+
+#### Option 1: Ollama (Recommended)
+
+[Ollama](https://ollama.com/) is a lightweight, easy-to-deploy inference server that supports both LLM chat and embedding models. It is the recommended backend for most deployments — whether local development, single-node GPU servers, or smaller production clusters.
+
+Ollama advantages:
+- Simple setup — single binary or container, no model compilation step
+- Supports CPU and GPU inference out of the box
+- Easy model management (`ollama pull`, `ollama run`)
+- Broad model support (Mistral, Llama, Gemma, BGE-M3, etc.)
+
+```yaml
+triton:
+  url: ""  # Disable Triton
+ollama:
+  baseUrl: "http://ollama.synaplan.svc.cluster.local:11434"
+```
+
+To deploy Ollama in your cluster, you can use the [ollama-helm](https://github.com/otwld/ollama-helm) chart or run it as a standalone container.
+
+#### Option 2: NVIDIA Triton
+
+[NVIDIA Triton Inference Server](https://developer.nvidia.com/triton-inference-server) is a high-performance inference platform designed for production GPU clusters. Use Triton when you need maximum throughput with TensorRT-LLM optimized models.
+
+Triton advantages:
+- TensorRT-LLM compiled models for maximum GPU throughput
+- Dynamic batching and model concurrency
+- Multi-model serving with fine-grained resource control
+- Production-grade metrics and monitoring
+
+Triton requires a separate deployment using the `triton` chart included in this repository:
+
+```yaml
+triton:
+  url: "triton:8001"
+ollama:
+  baseUrl: ""
+```
+
+See the [triton chart](../triton/) for deployment instructions and TensorRT-LLM build configuration.
+
 {{ template "chart.valuesSection" . }}
 
 ## Usage

--- a/charts/synaplan/values.yaml
+++ b/charts/synaplan/values.yaml
@@ -3,7 +3,7 @@ customRootCA: false
 # Public URL for accessing Synaplan (e.g., https://synaplan.example.com)
 publicUrl: ""
 
-# Triton deployment mode (cpu or gpu) - determines which model to register in database
+# -- Triton deployment mode (cpu or gpu) - determines which model to register in database
 tritonMode: "gpu"
 
 # Mailer configuration (Symfony mailer DSN)
@@ -38,14 +38,14 @@ database:
   serverVersion: "mariadb-11.7.1"
 
 # Triton Inference Server configuration
-# Optional: Leave url empty to disable Triton support
 triton:
+  # -- Triton gRPC endpoint URL. Leave empty to disable Triton backend.
   url: "triton:8001"
 
-# Ollama configuration (optional)
-# Alternative to Triton for local LLM inference
-# Example: http://ollama.synaplan.svc.cluster.local:11434
+# Ollama configuration — recommended alternative to Triton
 ollama:
+  # -- Ollama API base URL. Set this to use Ollama for LLM inference and bge-m3 embedding.
+  # Example: http://ollama.synaplan.svc.cluster.local:11434
   baseUrl: ""
 
 # Tika document processing service configuration


### PR DESCRIPTION
For a public OpenDesk integration with Nextcloud, I used Ollama in K8s for simple infering and embeding models!