### PR TITLE
feat: support extraInitScripts in values

### DIFF
--- a/charts/synaplan/README.md
+++ b/charts/synaplan/README.md
@@ -108,6 +108,7 @@ See the [triton chart](../triton/) for deployment instructions and TensorRT-LLM 
 | env[0].value | string | `"production"` |  |
 | env[1].name | string | `"APP_DEBUG"` |  |
 | env[1].value | string | `"false"` |  |
+| extraInitScripts | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"ghcr.io/metadist/synaplan"` |  |

--- a/charts/synaplan/templates/init-scripts-configmap.yaml
+++ b/charts/synaplan/templates/init-scripts-configmap.yaml
@@ -91,3 +91,7 @@ data:
     {{- end }}
 
     echo "✅ Default models initialized"
+  {{- range $name, $content := .Values.extraInitScripts }}
+  {{ $name }}: |
+    {{- $content | nindent 4 }}
+  {{- end }}

--- a/charts/synaplan/values.yaml
+++ b/charts/synaplan/values.yaml
@@ -136,6 +136,16 @@ service:
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
   port: 80
 
+# Additional init scripts to run on container startup
+# Scripts are added to the init-scripts ConfigMap and executed by docker-entrypoint.sh
+# Use numeric prefixes to control execution order (00-49: before DB, 50+: after DB)
+# Example:
+#   extraInitScripts:
+#     02-my-script.sh: |
+#       #!/bin/bash
+#       echo "Hello from my script"
+extraInitScripts: {}
+
 # Additional environment variables for the application
 # These are appended after the standard env vars defined in the deployment template
 env:


### PR DESCRIPTION
## Summary
- Add `extraInitScripts` map to values for injecting additional init scripts
- Scripts are rendered into the init-scripts ConfigMap alongside built-in scripts
- Executed by `docker-entrypoint.sh` on container startup

## Use case
Allows deployment-specific customizations (e.g. injecting a topbar script tag) without forking the chart.

## Test plan
- [ ] `helm template` renders extra scripts in the ConfigMap
- [ ] Scripts execute on pod startup in correct order