### PR TITLE
feat: add model and prompt initialization on startup

### DIFF
--- a/charts/synaplan/Chart.yaml
+++ b/charts/synaplan/Chart.yaml
@@ -3,7 +3,7 @@ name: synaplan
 description: Synaplan - AI-powered document analysis and planning platform
 type: application
 version: 0.1.0
-appVersion: "2.0.0"
+appVersion: "2.2.1"
 keywords:
   - synaplan
   - ai

--- a/charts/synaplan/README.md
+++ b/charts/synaplan/README.md
@@ -1,6 +1,6 @@
 # synaplan
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
 
 Synaplan - AI-powered document analysis and planning platform
 
@@ -92,6 +92,7 @@ See the [triton chart](../triton/) for deployment instructions and TensorRT-LLM 
 | apiKeys.braveSearch | string | `""` |  |
 | apiKeys.googleGemini | string | `""` |  |
 | apiKeys.groq | string | `""` |  |
+| apiKeys.huggingface | string | `""` |  |
 | apiKeys.openai | string | `""` |  |
 | apiKeysSecretRef | string | `""` |  |
 | autoscaling.enabled | bool | `false` |  |
@@ -124,8 +125,22 @@ See the [triton chart](../triton/) for deployment instructions and TensorRT-LLM 
 | livenessProbe.httpGet.path | string | `"/"` |  |
 | livenessProbe.httpGet.port | string | `"http"` |  |
 | mailerDsn | string | `"null://null"` |  |
+| models.defaults.analyze | string | `""` |  |
+| models.defaults.chat | string | `""` |  |
+| models.defaults.pic2text | string | `""` |  |
+| models.defaults.sort | string | `""` |  |
+| models.defaults.sound2text | string | `""` |  |
+| models.defaults.summarize | string | `""` |  |
+| models.defaults.text2pic | string | `""` |  |
+| models.defaults.text2sound | string | `""` |  |
+| models.defaults.text2vid | string | `""` |  |
+| models.defaults.tools | string | `""` |  |
+| models.defaults.vectorize | string | `""` |  |
+| models.disabled | list | `[]` |  |
+| models.enabled | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
+| oidc.autoRedirect | bool | `true` | Auto-redirect to OIDC provider on login page |
 | oidc.clientId | string | `""` |  |
 | oidc.clientSecret | string | `""` |  |
 | oidc.clientSecretRef | string | `""` |  |
@@ -140,6 +155,7 @@ See the [triton chart](../triton/) for deployment instructions and TensorRT-LLM 
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
+| prompts.seed | bool | `true` |  |
 | publicUrl | string | `""` |  |
 | readinessProbe.httpGet.path | string | `"/"` |  |
 | readinessProbe.httpGet.port | string | `"http"` |  |

--- a/charts/synaplan/templates/deployment.yaml
+++ b/charts/synaplan/templates/deployment.yaml
@@ -135,6 +135,16 @@ spec:
               {{- else }}
               value: {{ .Values.apiKeys.braveSearch | quote }}
               {{- end }}
+            - name: HUGGINGFACE_API_KEY
+              {{- if .Values.apiKeysSecretRef }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.apiKeysSecretRef | quote }}
+                  key: "huggingface-api-key"
+                  optional: true
+              {{- else }}
+              value: {{ .Values.apiKeys.huggingface | quote }}
+              {{- end }}
             {{- if .Values.oidc.enabled }}
             # OIDC Authentication
             - name: OIDC_DISCOVERY_URL
@@ -150,6 +160,8 @@ spec:
               {{- else }}
               value: {{ .Values.oidc.clientSecret | quote }}
               {{- end }}
+            - name: OIDC_AUTO_REDIRECT
+              value: {{ .Values.oidc.autoRedirect | quote }}
             {{- end }}
             {{- if .Values.tika.enabled }}
             # Tika Document Processing

--- a/charts/synaplan/templates/init-scripts-configmap.yaml
+++ b/charts/synaplan/templates/init-scripts-configmap.yaml
@@ -35,9 +35,8 @@ data:
     # Wait for database connection to be ready
     # All scripts numbered 51+ will run after database is available
 
-    echo "⏳ Waiting for database connection..."
-
     cd /var/www/backend
+    echo "⏳ Waiting for database connection..."
 
     for i in {1..60}; do
       if php bin/console dbal:run-sql "SELECT 1" > /dev/null 2>&1; then
@@ -52,10 +51,9 @@ data:
 
   51-init-models.sh: |
     #!/bin/bash
-    # Initialize default models for Triton/Mistral
+    set -e
+    # Sync AI models using built-in catalog commands
     # Runs after database is ready (50-wait-database.sh)
-
-    echo "🔧 Initializing default AI models..."
 
     cd /var/www/backend
 
@@ -65,32 +63,40 @@ data:
     php bin/console doctrine:schema:update --force
     echo "✅ Database schema ready!"
 
-    # Note: SQL queries below use hardcoded strings only (no variable interpolation)
-    # This is safe from SQL injection as all values are defined in the Helm template
-    #
-    # The hardcoded BID=100 is intentional and uses ON DUPLICATE KEY UPDATE to:
-    # - Ensure idempotent behavior (safe to run on every pod start)
-    # - Keep model configuration up-to-date if the chart is updated
-    # - Provide a deterministic ID for the default Triton model
-    {{- if eq .Values.tritonMode "gpu" }}
-    # Insert Triton Mistral model for GPU mode (uses mistral-streaming with TensorRT-LLM backend)
-    if php bin/console dbal:run-sql "INSERT INTO BMODELS (BID, BSERVICE, BNAME, BTAG, BSELECTABLE, BACTIVE, BPROVID, BPRICEIN, BINUNIT, BPRICEOUT, BOUTUNIT, BQUALITY, BRATING, BISDEFAULT, BDESCRIPTION, BJSON) VALUES (100, 'triton', 'mistral-7b (streaming)', 'chat', 1, 1, 'mistral-streaming', 0.0, 'per1M', 0.0, 'per1M', 7.0, 0.5, 1, 'Mistral 7B model via Triton Inference Server with GPU acceleration and streaming support', '{\"description\": \"Triton Inference Server model with TensorRT-LLM backend and streaming capabilities\", \"features\": [\"streaming\", \"gpu\"], \"supportsStreaming\": true}') ON DUPLICATE KEY UPDATE BSERVICE = VALUES(BSERVICE), BNAME = VALUES(BNAME), BPROVID = VALUES(BPROVID), BJSON = VALUES(BJSON)" 2>&1 | grep -q "rows affected"; then
-      echo "   ✅ Triton model registered (GPU mode: mistral-streaming)"
-    else
-      echo "   ❌ Failed to register Triton model"
-      exit 1
-    fi
-    {{- else }}
-    # Insert Triton Mistral model for CPU mode (uses mistral-cpu with PyTorch backend)
-    if php bin/console dbal:run-sql "INSERT INTO BMODELS (BID, BSERVICE, BNAME, BTAG, BSELECTABLE, BACTIVE, BPROVID, BPRICEIN, BINUNIT, BPRICEOUT, BOUTUNIT, BQUALITY, BRATING, BISDEFAULT, BDESCRIPTION, BJSON) VALUES (100, 'triton', 'mistral-7b (cpu)', 'chat', 1, 1, 'mistral-cpu', 0.0, 'per1M', 0.0, 'per1M', 7.0, 0.5, 1, 'Mistral 7B model via Triton Inference Server with CPU inference', '{\"description\": \"Triton Inference Server model with PyTorch CPU backend\", \"features\": [\"cpu\", \"streaming\"], \"supportsStreaming\": true}') ON DUPLICATE KEY UPDATE BSERVICE = VALUES(BSERVICE), BNAME = VALUES(BNAME), BPROVID = VALUES(BPROVID), BJSON = VALUES(BJSON)" 2>&1 | grep -q "rows affected"; then
-      echo "   ✅ Triton model registered (CPU mode: mistral-cpu)"
-    else
-      echo "   ❌ Failed to register Triton model"
-      exit 1
-    fi
+    {{- if .Values.prompts.seed }}
+    # Seed built-in system prompts
+    synaplan prompt:seed
     {{- end }}
 
-    echo "✅ Default models initialized"
+    {{- $regularModels := list }}
+    {{- $systemModels := list }}
+    {{- range .Values.models.enabled }}
+    {{- if kindIs "string" . }}
+    {{- $regularModels = append $regularModels . }}
+    {{- else }}
+    {{- if .system }}
+    {{- $systemModels = append $systemModels .name }}
+    {{- else }}
+    {{- $regularModels = append $regularModels .name }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- if $regularModels }}
+    synaplan model:enable {{ $regularModels | join " " }}
+    {{- end }}
+    {{- if $systemModels }}
+    synaplan model:enable --system {{ $systemModels | join " " }}
+    {{- end }}
+
+    {{- if .Values.models.disabled }}
+    synaplan model:disable {{ .Values.models.disabled | join " " }}
+    {{- end }}
+
+    {{- range $capability, $modelKey := .Values.models.defaults }}
+    {{- if $modelKey }}
+    synaplan model:set-default {{ $modelKey }} {{ $capability }}
+    {{- end }}
+    {{- end }}
   {{- range $name, $content := .Values.extraInitScripts }}
   {{ $name }}: |
     {{- $content | nindent 4 }}

--- a/charts/synaplan/values.yaml
+++ b/charts/synaplan/values.yaml
@@ -18,6 +18,7 @@ apiKeys:
   groq: ""
   googleGemini: ""
   braveSearch: ""
+  huggingface: ""
 
 # Option 2: Reference existing secrets (recommended for production)
 # Create secret: kubectl create secret generic synaplan-api-keys \
@@ -25,7 +26,8 @@ apiKeys:
 #   --from-literal=openai-api-key=YOUR_KEY \
 #   --from-literal=groq-api-key=YOUR_KEY \
 #   --from-literal=google-gemini-api-key=YOUR_KEY \
-#   --from-literal=brave-search-api-key=YOUR_KEY
+#   --from-literal=brave-search-api-key=YOUR_KEY \
+#   --from-literal=huggingface-api-key=YOUR_KEY
 # Then set: apiKeysSecretRef: "synaplan-api-keys"
 apiKeysSecretRef: ""
 
@@ -65,6 +67,37 @@ oidc:
   # Create secret: kubectl create secret generic synaplan-oidc-credentials --from-literal=client-secret=YOUR_SECRET
   # Then set: clientSecretRef: "synaplan-oidc-credentials"
   clientSecretRef: ""
+  # -- Auto-redirect to OIDC provider on login page
+  autoRedirect: true
+
+# Seed built-in system prompts on startup (idempotent)
+prompts:
+  seed: true
+
+# AI models to enable/disable from the built-in catalog on startup
+# Keys use the format "service:providerId" (e.g. "groq:llama-3.3-70b-versatile")
+# Entries can be strings or objects with a "system" flag to lock the model:
+#   enabled:
+#     - "groq:llama-3.3-70b-versatile"
+#     - name: "ollama:bge-m3"
+#       system: true
+models:
+  enabled: []
+  disabled: []
+  # Default model per capability. Empty string = skip (no default set).
+  # Keys use the same format as enable/disable (e.g. "groq:llama-3.3-70b-versatile")
+  defaults:
+    chat: ""
+    tools: ""
+    sort: ""
+    summarize: ""
+    text2pic: ""
+    text2vid: ""
+    text2sound: ""
+    pic2text: ""
+    sound2text: ""
+    vectorize: ""
+    analyze: ""
 
 # Persistence configuration for Synaplan data
 persistence:


### PR DESCRIPTION
## Summary

- **Prompt seeding**: `prompts.seed: true` (opt-out) runs `synaplan prompt:seed` on startup to upsert built-in system prompts
- **Model enable/disable**: Renamed `models.enable`/`disable` to `models.enabled`/`disabled`
- **System models**: Support mixed enable format — plain strings or `{name, system: true}` objects. System models are locked in the UI.
- **Model defaults**: `models.defaults` map sets default model per capability (chat, vectorize, etc.) via `synaplan model:set-default`
- **Huggingface API key**: Added to deployment env vars and values

## Depends on

- metadist/synaplan#453 (`model:set-default` command, `--system` flag)
- metadist/synaplan#454 (`prompt:seed` command, `PromptCatalog`)

## Test plan

- [x] `helm template` renders correctly
- [x] Deployed to vs-ap-red — prompts seeded, models enabled with defaults