### PR TITLE
fix: improve chart defaults for production deployments

### DIFF
--- a/charts/synaplan/README.md
+++ b/charts/synaplan/README.md
@@ -106,7 +106,7 @@ See the [triton chart](../triton/) for deployment instructions and TensorRT-LLM 
 | database.serverVersion | string | `"mariadb-11.7.1"` |  |
 | database.user | string | `"synaplan"` |  |
 | env[0].name | string | `"APP_ENV"` |  |
-| env[0].value | string | `"production"` |  |
+| env[0].value | string | `"prod"` |  |
 | env[1].name | string | `"APP_DEBUG"` |  |
 | env[1].value | string | `"false"` |  |
 | extraInitScripts | object | `{}` |  |
@@ -122,8 +122,11 @@ See the [triton chart](../triton/) for deployment instructions and TensorRT-LLM 
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
+| livenessProbe.failureThreshold | int | `3` |  |
 | livenessProbe.httpGet.path | string | `"/"` |  |
 | livenessProbe.httpGet.port | string | `"http"` |  |
+| livenessProbe.initialDelaySeconds | int | `120` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
 | mailerDsn | string | `"null://null"` |  |
 | models.defaults.analyze | string | `""` |  |
 | models.defaults.chat | string | `""` |  |
@@ -157,8 +160,11 @@ See the [triton chart](../triton/) for deployment instructions and TensorRT-LLM 
 | podSecurityContext | object | `{}` |  |
 | prompts.seed | bool | `true` |  |
 | publicUrl | string | `""` |  |
+| readinessProbe.failureThreshold | int | `3` |  |
 | readinessProbe.httpGet.path | string | `"/"` |  |
 | readinessProbe.httpGet.port | string | `"http"` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
+| readinessProbe.periodSeconds | int | `5` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |

--- a/charts/synaplan/templates/deployment.yaml
+++ b/charts/synaplan/templates/deployment.yaml
@@ -163,6 +163,9 @@ spec:
             - name: OIDC_AUTO_REDIRECT
               value: {{ .Values.oidc.autoRedirect | quote }}
             {{- end }}
+            # Lock backend (Symfony Lock component)
+            - name: LOCK_DSN
+              value: "flock"
             {{- if .Values.tika.enabled }}
             # Tika Document Processing
             - name: TIKA_BASE_URL

--- a/charts/synaplan/values.yaml
+++ b/charts/synaplan/values.yaml
@@ -183,7 +183,7 @@ extraInitScripts: {}
 # These are appended after the standard env vars defined in the deployment template
 env:
   - name: APP_ENV
-    value: "production"
+    value: "prod"
   - name: APP_DEBUG
     value: "false"
 
@@ -221,10 +221,16 @@ livenessProbe:
   httpGet:
     path: /
     port: http
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  failureThreshold: 3
 readinessProbe:
   httpGet:
     path: /
     port: http
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  failureThreshold: 3
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:


### PR DESCRIPTION
## Summary
- Fix `APP_ENV` default from `"production"` to `"prod"` (correct Symfony environment value)
- Add `LOCK_DSN=flock` as a built-in env var in the deployment template (required by Symfony Lock component, was previously missing causing CrashLoopBackOff)
- Add reasonable liveness/readiness probe timing defaults (`initialDelaySeconds`, `periodSeconds`, `failureThreshold`)