### PR TITLE
feat: TTS support

### DIFF
--- a/charts/synaplan/README.md
+++ b/charts/synaplan/README.md
@@ -179,6 +179,7 @@ See the [triton chart](../triton/) for deployment instructions and TensorRT-LLM 
 | tolerations | list | `[]` |  |
 | triton.url | string | `"triton:8001"` | Triton gRPC endpoint URL. Leave empty to disable Triton backend. |
 | tritonMode | string | `"gpu"` | Triton deployment mode (cpu or gpu) - determines which model to register in database |
+| tts | object | `{"defaultVoice":"en_US-lessac-medium","enabled":false,"huggingfaceVoices":{"image":{"repository":"python","tag":"3.11-slim"},"repo":"rhasspy/piper-voices","revision":"","voices":[{"name":"en_US-lessac-medium","subfolder":"en/en_US/lessac/medium"},{"name":"de_DE-thorsten-medium","subfolder":"de/de_DE/thorsten/medium"}]},"image":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/metadist/synaplan-tts","tag":"latest"},"maxTextLength":"5000","persistence":{"accessMode":"ReadWriteOnce","size":"5Gi","storageClass":""},"port":10200,"synthWorkers":"4"}` | TTS (text-to-speech) sub-deployment using Piper voices |
 | volumeMounts | list | `[]` |  |
 | volumes | list | `[]` |  |
 

--- a/charts/synaplan/templates/deployment.yaml
+++ b/charts/synaplan/templates/deployment.yaml
@@ -171,6 +171,11 @@ spec:
             - name: TIKA_BASE_URL
               value: {{ .Values.tika.url | quote }}
             {{- end }}
+            {{- if .Values.tts.enabled }}
+            # TTS (text-to-speech)
+            - name: SYNAPLAN_TTS_URL
+              value: "http://{{ include "synaplan.fullname" . }}-tts:{{ .Values.tts.port }}"
+            {{- end }}
             {{- with .Values.env }}
             # Additional environment variables
             {{- toYaml . | nindent 12 }}

--- a/charts/synaplan/templates/tts-deployment.yaml
+++ b/charts/synaplan/templates/tts-deployment.yaml
@@ -1,0 +1,130 @@
+{{- if .Values.tts.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "synaplan.fullname" . }}-tts
+  labels:
+    {{- include "synaplan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tts
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "synaplan.name" . }}-tts
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "synaplan.name" . }}-tts
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if gt (len .Values.tts.huggingfaceVoices.voices) 0 }}
+      initContainers:
+        - name: voice-downloader
+          image: "{{ .Values.tts.huggingfaceVoices.image.repository }}:{{ .Values.tts.huggingfaceVoices.image.tag }}"
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -euo pipefail
+
+              echo "Installing huggingface-hub CLI..."
+              pip install --no-cache-dir huggingface-hub
+
+              REPO_ID="{{ .Values.tts.huggingfaceVoices.repo }}"
+              {{- if .Values.tts.huggingfaceVoices.revision }}
+              REVISION="{{ .Values.tts.huggingfaceVoices.revision }}"
+              {{- else }}
+              REVISION=""
+              {{- end }}
+
+              {{- range .Values.tts.huggingfaceVoices.voices }}
+              # Download voice: {{ .name }}
+              VOICE_NAME="{{ .name }}"
+              SUBFOLDER="{{ .subfolder }}"
+              MARKER="/voices/.${VOICE_NAME}.download_complete"
+
+              if [ -f "$MARKER" ]; then
+                echo "Voice $VOICE_NAME already exists, skipping download..."
+              else
+                # Remove partial download if exists
+                rm -f "/voices/${VOICE_NAME}.onnx" "/voices/${VOICE_NAME}.onnx.json"
+
+                echo "Downloading voice: $VOICE_NAME from $REPO_ID/$SUBFOLDER"
+
+                python -c "
+              from huggingface_hub import hf_hub_download
+              import shutil
+              revision = '$REVISION' or None
+              for ext in ['.onnx', '.onnx.json']:
+                  path = hf_hub_download(
+                      repo_id='$REPO_ID',
+                      filename='$VOICE_NAME' + ext,
+                      subfolder='$SUBFOLDER',
+                      revision=revision,
+                  )
+                  shutil.copy2(path, '/voices/$VOICE_NAME' + ext)
+                  print(f'Downloaded $VOICE_NAME{ext}')
+              "
+
+                # Mark download as complete
+                touch "$MARKER"
+                echo "Voice $VOICE_NAME download complete!"
+              fi
+              {{- end }}
+
+              echo "All voices downloaded. Contents of /voices:"
+              find /voices -type f | head -20
+          volumeMounts:
+            - name: tts-voices
+              mountPath: /voices
+      {{- end }}
+      containers:
+        - name: tts
+          image: "{{ .Values.tts.image.repository }}:{{ .Values.tts.image.tag }}"
+          imagePullPolicy: {{ .Values.tts.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.tts.port }}
+              protocol: TCP
+          env:
+            - name: VOICES_DIR
+              value: "/voices"
+            - name: DEFAULT_VOICE
+              value: {{ .Values.tts.defaultVoice | quote }}
+            - name: MAX_TEXT_LENGTH
+              value: {{ .Values.tts.maxTextLength | quote }}
+            - name: SYNTH_WORKERS
+              value: {{ .Values.tts.synthWorkers | quote }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: tts-voices
+              mountPath: /voices
+      volumes:
+        - name: tts-voices
+          persistentVolumeClaim:
+            claimName: {{ include "synaplan.fullname" . }}-tts-voices-pvc
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/synaplan/templates/tts-pvc.yaml
+++ b/charts/synaplan/templates/tts-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.tts.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "synaplan.fullname" . }}-tts-voices-pvc
+  labels:
+    {{- include "synaplan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tts
+spec:
+  accessModes:
+    - {{ .Values.tts.persistence.accessMode | default "ReadWriteOnce" }}
+  resources:
+    requests:
+      storage: {{ .Values.tts.persistence.size | default "5Gi" }}
+  {{- if .Values.tts.persistence.storageClass }}
+  storageClassName: {{ .Values.tts.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/synaplan/templates/tts-service.yaml
+++ b/charts/synaplan/templates/tts-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.tts.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "synaplan.fullname" . }}-tts
+  labels:
+    {{- include "synaplan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tts
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.tts.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "synaplan.name" . }}-tts
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/synaplan/values.yaml
+++ b/charts/synaplan/values.yaml
@@ -99,6 +99,36 @@ models:
     vectorize: ""
     analyze: ""
 
+# -- TTS (text-to-speech) sub-deployment using Piper voices
+tts:
+  enabled: false
+  image:
+    repository: ghcr.io/metadist/synaplan-tts
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  port: 10200
+  defaultVoice: "en_US-lessac-medium"
+  maxTextLength: "5000"
+  synthWorkers: "4"
+  # Voice models downloaded from HuggingFace by init container.
+  # Uses same python:3.11-slim + huggingface-hub pattern as triton chart's huggingfaceModels.
+  # Set voices: [] to skip all downloads (bring your own voices on the PVC).
+  huggingfaceVoices:
+    image:
+      repository: python
+      tag: "3.11-slim"
+    repo: "rhasspy/piper-voices"
+    revision: ""  # pin to a known-good commit hash (recommended)
+    voices:
+      - name: "en_US-lessac-medium"
+        subfolder: "en/en_US/lessac/medium"
+      - name: "de_DE-thorsten-medium"
+        subfolder: "de/de_DE/thorsten/medium"
+  persistence:
+    size: "5Gi"
+    accessMode: "ReadWriteOnce"
+    storageClass: ""
+
 # Persistence configuration for Synaplan data
 persistence:
   # User uploads - REQUIRED for production

--- a/deployments/synaplan-with-triton/README.md
+++ b/deployments/synaplan-with-triton/README.md
@@ -121,12 +121,15 @@ After deployment, access Synaplan at the configured URL (e.g., `https://synaplan
 After deployment, create an initial admin user:
 
 ```bash
-NS=synaplan  # adjust to your namespace
-kubectl exec -n $NS deployment/synaplan -- php -r '
-$pdo = new PDO("mysql:host=mariadb-cluster.'.$NS'.svc.cluster.local;dbname=synaplan", "synaplan", getenv("DB_PASSWORD"));
-$pdo->exec("INSERT INTO BUSER (BCREATED, BINTYPE, BMAIL, BPW, BPROVIDERID, BUSERLEVEL, BEMAILVERIFIED, BUSERDETAILS, BPAYMENTDETAILS) VALUES (\"".date("Y-m-d H:i:s")."\", \"WEB\", \"admin@example.com\", \"".password_hash("changeme", PASSWORD_BCRYPT)."\", \"local\", \"ADMIN\", 1, \"{}\", \"{}\")");
-echo "Admin user created\n";
-'
+NS=synaplan              # adjust to your namespace
+MAIL=admin@example.com   # adjust to your email
+PW=CHANGE-ME-NOW         # use a strong password
+
+kubectl exec -n "$NS" deployment/synaplan -- php -r "
+\$pdo = new PDO('mysql:host=mariadb-cluster.$NS.svc.cluster.local;dbname=synaplan', 'synaplan', getenv('DB_PASSWORD'));
+\$pdo->exec(\"INSERT INTO BUSER (BCREATED, BINTYPE, BMAIL, BPW, BPROVIDERID, BUSERLEVEL, BEMAILVERIFIED, BUSERDETAILS, BPAYMENTDETAILS) VALUES ('\" . date('Y-m-d H:i:s') . \"', 'WEB', '$MAIL', '\" . password_hash('$PW', PASSWORD_BCRYPT) . \"', 'local', 'ADMIN', 1, '{}', '{}')\");
+echo \"Admin user created\n\";
+"
 ```
 
 ## Verify Deployment

--- a/deployments/synaplan-with-triton/environments/default/values.yaml
+++ b/deployments/synaplan-with-triton/environments/default/values.yaml
@@ -16,9 +16,19 @@ services:
         - "triton:gpt-oss-20b"
         - "triton:bge-m3"
         - "triton:mistral-7b-instruct-v0.3"
+        - "piper:piper-multi"
       defaults:
         chat: "triton:gpt-oss-20b"
         sort: "triton:gpt-oss-20b"
         vectorize: "triton:bge-m3"
+        text2sound: "piper:piper-multi"
+  tts:
+    enabled: true
+    huggingfaceVoices:
+      voices:
+        - name: "en_US-lessac-medium"
+          subfolder: "en/en_US/lessac/medium"
+        - name: "de_DE-thorsten-medium"
+          subfolder: "de/de_DE/thorsten/medium"
   triton:
     mode: gpu

--- a/deployments/synaplan-with-triton/helmfile.yaml.gotmpl
+++ b/deployments/synaplan-with-triton/helmfile.yaml.gotmpl
@@ -48,6 +48,10 @@ releases:
   - name: synaplan
     namespace: {{ $ns }}
     chart: ../../charts/synaplan
+    needs:
+      - {{ $ns }}/mariadb-cluster
+      - {{ $ns }}/tika
+      - {{ $ns }}/triton
     values:
       - values-synaplan.yaml.gotmpl
 

--- a/deployments/synaplan-with-triton/values-synaplan.yaml.gotmpl
+++ b/deployments/synaplan-with-triton/values-synaplan.yaml.gotmpl
@@ -62,10 +62,16 @@ oidc:
   {{- end }}
   {{- end }}
 
+{{- with .Values.services | getOrNil "tts" }}
+tts:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+
 {{- with .Values | getOrNil "persistence" }}
 persistence:
   {{- with index . "uploads" }}
   uploads:
+    enabled: true
     {{- with index . "accessMode" }}
     accessMode: {{ . | quote }}
     {{- end }}


### PR DESCRIPTION
## Summary
- Add optional TTS (text-to-speech) sub-deployment to the synaplan chart using Piper voices
  - Deployment, Service, PVC templates, toggled by `tts.enabled`
  - HuggingFace voice download init container (same `python:3.11-slim` + `huggingface-hub` pattern as triton chart)
  - `SYNAPLAN_TTS_URL` env var injected into main deployment when enabled
  - Piper model enabled and set as default for `text2sound` capability
- Add tika chart and configurable namespace to helmfile
- Fix values template: optional OIDC, certIssuer, persistence, image override; only emit values when set to avoid overriding chart defaults
- Add model defaults for chat, sort, vectorize, and text2sound
- Fix serverVersion format for MariaDB 11.7
- Helmfile `needs` for correct release ordering
- Fix `persistence.uploads.enabled` not being set in values template
- Improve admin user creation script with variables and obvious placeholder password
- Document admin user creation in README

## Follow-up
- Memories / Qdrant integration (deferred — repo needs cleanup)

## Test plan
- [x] `helmfile -e vultr destroy` + `helmfile -e vultr sync` deploys cleanly from scratch
- [x] Init scripts create schema, enable models, set defaults (chat, sort, vectorize, text2sound)
- [x] Chat works end-to-end with triton provider
- [x] TTS voices downloaded via HuggingFace init container (2 voices loaded)
- [x] TTS health check returns OK from within cluster
- [x] Piper provider registered and set as text2sound default