### PR TITLE
feat: add configurable OIDC scopes

### DIFF
--- a/charts/synaplan/README.md
+++ b/charts/synaplan/README.md
@@ -149,6 +149,7 @@ See the [triton chart](../triton/) for deployment instructions and TensorRT-LLM 
 | oidc.clientSecretRef | string | `""` |  |
 | oidc.enabled | bool | `false` |  |
 | oidc.issuerURI | string | `""` |  |
+| oidc.scopes | string | `"openid email profile offline_access"` | Space-separated OIDC scopes requested during login. Remove offline_access if your provider doesn't support it (internal app tokens provide a 7-day fallback). |
 | ollama.baseUrl | string | `""` | Ollama API base URL. Set this to use Ollama for LLM inference and bge-m3 embedding. Example: http://ollama.synaplan.svc.cluster.local:11434 |
 | persistence.uploads.accessMode | string | `"ReadWriteMany"` |  |
 | persistence.uploads.enabled | bool | `false` |  |

--- a/charts/synaplan/templates/deployment.yaml
+++ b/charts/synaplan/templates/deployment.yaml
@@ -162,6 +162,10 @@ spec:
               {{- end }}
             - name: OIDC_AUTO_REDIRECT
               value: {{ .Values.oidc.autoRedirect | quote }}
+            {{- if .Values.oidc.scopes }}
+            - name: OIDC_SCOPES
+              value: {{ .Values.oidc.scopes | quote }}
+            {{- end }}
             {{- end }}
             # Lock backend (Symfony Lock component)
             - name: LOCK_DSN

--- a/charts/synaplan/values.yaml
+++ b/charts/synaplan/values.yaml
@@ -69,6 +69,9 @@ oidc:
   clientSecretRef: ""
   # -- Auto-redirect to OIDC provider on login page
   autoRedirect: true
+  # -- Space-separated OIDC scopes requested during login.
+  # Remove offline_access if your provider doesn't support it (internal app tokens provide a 7-day fallback).
+  scopes: "openid email profile offline_access"
 
 # Seed built-in system prompts on startup (idempotent)
 prompts:


### PR DESCRIPTION
## Summary
- Add `oidc.scopes` value (default: `openid email profile offline_access`) for configuring OIDC scopes
- Maps to `OIDC_SCOPES` env var in the deployment, only rendered when non-empty
- Companion to metadist/synaplan#500

## Test plan
- [ ] `helm template` with default values — `OIDC_SCOPES` rendered with default
- [ ] `helm template` with `oidc.scopes: "openid email profile"` — no `offline_access`
- [ ] `helm template` with `oidc.scopes: ""` — `OIDC_SCOPES` env var omitted entirely